### PR TITLE
Whole project checking.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode'
-import {checkSchema} from 'bebop-tools'
+import { checkProject, checkSchema, ensurePermissions } from 'bebop-tools'
 import path = require('path')
 import child_process = require('child_process')
 import util = require('util')
@@ -9,23 +9,7 @@ import util = require('util')
 const exec = util.promisify(child_process.exec)
 
 let diagnosticCollection: vscode.DiagnosticCollection
-let diagnosticMap: Map<vscode.Uri, vscode.Diagnostic[]> = new Map()
-
-async function ensurePermissions() {
-	const toolsDir = path.resolve(require.resolve('bebop-tools'), '../../tools')
-	if (process.platform === "darwin") {
-		const executable = path.resolve(toolsDir, 'macos/bebopc')
-		await exec(`chmod +x "${executable}"`)
-	}
-	else if (process.platform === "linux") {
-		const executable = path.resolve(toolsDir, 'linux/bebopc')
-		await exec(`chmod +x "${executable}"`)
-	}
-	else if (process.platform === "win32") {
-		const executable = path.resolve(toolsDir, 'windows/bebopc.exe')
-		await exec(`Unblock-File -Path "${executable}"`, {shell: "powershell.exe"})
-	}
-}
+let diagnosticMap: Map<string, vscode.Diagnostic[]> = new Map()
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -40,15 +24,43 @@ export async function activate(context: vscode.ExtensionContext) {
 	if (vscode.window.activeTextEditor?.document) {
 		updateDiagnostics(vscode.window.activeTextEditor.document)
 	}
-	const onChangeEditorDisposable = vscode.window.onDidChangeActiveTextEditor((event) => {
+	/* const onChangeEditorDisposable = vscode.window.onDidChangeActiveTextEditor((event) => {
 		if (event?.document) {
 			updateDiagnostics(event.document)
 		}
+	}) */
+	const onSaveDisposable = vscode.workspace.onDidSaveTextDocument((document) => {
+		updateDiagnostics(document)
 	})
 	const onChangeDisposable = vscode.workspace.onDidChangeTextDocument((event) => {
-		updateDiagnostics(event.document)
+		clearDiagnosticsForDirty(event.document)
 	})
-	context.subscriptions.push(onChangeDisposable, onChangeEditorDisposable)
+	context.subscriptions.push(onSaveDisposable, onChangeDisposable)
+	//context.subscriptions.push(onChangeDisposable, onChangeEditorDisposable)
+}
+
+/**
+ * We currently have no way to run diagnostics on dirty files AND
+ * the rest of the project, which is necessary to check imports.
+ * So instead, warn the user to save the dirty file to see diagnostics.
+ */
+function clearDiagnosticsForDirty(document: vscode.TextDocument) {
+	if (document.languageId === 'bebop' && document.isDirty) {
+		/* let checked = false */
+		const diagnostic = new vscode.Diagnostic(
+			new vscode.Range(0, 0, 0, 1), 
+			"Save file to see diagnostics.", 
+			vscode.DiagnosticSeverity.Information
+		)
+		diagnosticCollection.set(document.uri, [diagnostic])
+		/* diagnosticCollection.forEach((uri, diagnostics) => {
+			if (uri.toString() === document.uri.toString()) {
+				diagnosticCollection.set(uri, [diagnostic])
+				checked = true
+			}
+		}) */
+		
+	}
 }
 
 /** To be run on file change. Runs compiler in check mode and loads diagnostics. */
@@ -57,18 +69,33 @@ async function updateDiagnostics(document: vscode.TextDocument) {
 		const uri = document.uri
 		if (uri.scheme === 'file') {
 			diagnosticCollection.clear()
-			const checkOutput = await checkSchema(document.getText())
-			const issues = checkOutput.issues
-			const diagnostics = []
-			if (issues?.length) {
+			// Just for right now
+			diagnosticMap.clear()
+			//const checkOutput = await checkSchema(document.getText())
+			const checkOutput = await checkProject({directory: path.resolve(document.uri.fsPath, "..")})
+			console.log(checkOutput)
+			if (checkOutput.error) {
+				const issues = checkOutput.issues
+				const seenUris: string[] = []
 				for (const issue of issues) {
 					let range = new vscode.Range(issue.startLine, issue.startColumn, issue.endLine, issue.endColumn)
-					diagnostics.push(new vscode.Diagnostic(range, issue.description, vscode.DiagnosticSeverity.Error))
+					const issueUri = vscode.Uri.file(issue.fileName)
+					const diagnostic = new vscode.Diagnostic(range, issue.description, vscode.DiagnosticSeverity.Error)
+					console.log(seenUris)
+					if (!seenUris.includes(issueUri.toString())) {
+						diagnosticMap.set(issueUri.toString(), [])
+					}
+					const diagnosticsForUri = diagnosticMap.get(issueUri.toString())
+					diagnosticsForUri!.push(diagnostic)
+					seenUris.push(issueUri.toString())
 				}
 			}
-			diagnosticMap.set(uri, diagnostics)
+			else {
+				diagnosticMap.clear()
+			}
 			for (const [uri, diagnostics] of diagnosticMap) {
-				diagnosticCollection.set(uri, diagnostics)
+				diagnosticCollection.set(vscode.Uri.parse(uri), diagnostics)
+				console.log(uri, diagnostics)
 			}
 		}
 	}


### PR DESCRIPTION
Diagnostics now work with import statements and take the entire project into account. There are still a few limitations: it is unable to check properly unless all changes are saved, so it shows an info diagnostic to the user when the file is dirty. Additionally, bebopc always exits after it encounters its first error, so only one diagnostic can be shown at a time across the entire project.

This depends upon my latest changes to bebopc.