### PR TITLE
Add syntax highlighting for consts

### DIFF
--- a/syntaxes/bebop.tmLanguage.json
+++ b/syntaxes/bebop.tmLanguage.json
@@ -317,7 +317,8 @@
 					"include": "#builtin_type"
 				},
 				{
-					"match": "="
+					"match": "=",
+					"name": "keyword.operator.bop"
 				},
 				{
 					"include": "#datetime"

--- a/syntaxes/bebop.tmLanguage.json
+++ b/syntaxes/bebop.tmLanguage.json
@@ -23,6 +23,9 @@
 		},
 		{
 			"include": "#enum"
+		},
+		{
+			"include": "#const"
 		}
 	],
 	"repository": {
@@ -292,6 +295,48 @@
 				}
 			]
 		},
+		"const": {
+			"name": "meta.const.bop",
+			"begin": "(const)\\s+",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.other.bop"
+				}
+			},
+			"end": "(;)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.terminator.bop"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#builtin_type"
+				},
+				{
+					"match": "="
+				},
+				{
+					"include": "#datetime"
+				},
+				{
+					"include": "#num_const"
+				},
+				{
+					"match": "(true|false)",
+					"name": "constant.language.boolean.bop"
+				},
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#ident"
+				}
+			]
+		},
 		"ident": {
 			"match": "\\b[A-Za-z][A-Za-z0-9_]*\\b",
 			"name": "entity.name.type.bop"
@@ -301,8 +346,19 @@
 			"name": "storage.type.bop"
 		},
 		"string": {
-			"match": "\"([^\"]|\\\")*\"",
-			"name": "string.quoted.double.bop"
+			"name": "string.quoted.double.bop",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [
+				{
+					"match": "\"([^\"]|\\\")*\"",
+					"name": "string.quoted.double.bop"
+				}
+			]
+		},
+		"num_const": {
+			"name": "constant.numeric.bop",
+			"match": "-?\\b(inf|nan|0[xX][0-9a-fA-F]+|[0-9]+)(\\.?[e0-9]*)\\b"
 		},
 		"number": {
 			"name": "constant.numeric.bop",
@@ -315,6 +371,10 @@
 		"type_punctuation": {
 			"name": "punctuation.type.bop",
 			"match": "\\[|\\]|,"
+		},
+		"datetime": {
+			"name": "constant.language",
+			"match": "\\b[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\\b"
 		}
 	}
 }


### PR DESCRIPTION
This change adds proper syntax highlighting for const declarations and their constants to the textmate grammar, which was previously missing.